### PR TITLE
feat: add /connpass report subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Connpass のイベント情報を定期取得し、Discord チャンネルへ新
 
 ## スラッシュコマンド
 
-- `/connpass set`
+- `/connpass feed set`
   - **interval_sec**: 実行間隔秒（既定 1800）
   - **keywords_and**: AND 検索キーワード（カンマ/スペース区切り、複数可）
   - **keywords_or**: OR 検索キーワード（カンマ/スペース区切り、複数可）
@@ -65,20 +65,25 @@ Connpass のイベント情報を定期取得し、Discord チャンネルへ新
   - **range_days**: 検索範囲日数（既定 14）
   - **location**: 開催地の都道府県（オートコンプリート対応、カンマ区切りで複数指定可）
   - **hashtag**: ハッシュタグ（先頭の `#` は不要、完全一致）
+  - **order**: 並び順（任意）— `updated_desc` | `started_asc` | `started_desc`
   - **owner_nickname**: 主催者ニックネーム
+- `/connpass feed sort`
+  - **order**: 並び順の種類
+    - `更新日時の降順 (updated_desc)` → API `order=1`
+    - `開催日時の昇順 (started_asc)` → API `order=2`（既定）
+    - `開催日時の降順 (started_desc)` → API `order=3`
+- `/connpass feed status`: 現在の監視設定表示
+- `/connpass feed remove`: 監視の削除
+- `/connpass feed run`: 手動実行
 - `/connpass user register`
   - **nickname**: あなたの Connpass ニックネーム
 - `/connpass user show`: 登録済みのニックネームを表示（未登録なら案内）
 - `/connpass user unregister`: ニックネームの登録解除
 - `/connpass today`: あなたが参加登録している今日のイベントを表示
-- `/connpass sort`
-  - **order**: 並び順の種類
-    - `更新日時の降順 (updated_desc)` → API `order=1`
-    - `開催日時の昇順 (started_asc)` → API `order=2`（既定）
-    - `開催日時の降順 (started_desc)` → API `order=3`
-- `/connpass status`: 現在の設定表示
-- `/connpass remove`: 監視の削除
-- `/connpass run`: 手動実行
+- `/connpass report`: 条件に合うイベントを広めの既定値で集約して投稿（オンデマンド）
+  - 既定: `range_days=30`, `order=started_asc`
+  - オプション: `keywords_and`, `keywords_or`, `range_days`, `location`, `hashtag`, `owner_nickname`, `order`
+  - 出力は2000文字制限に合わせて自動分割
 
 ジョブIDはチャンネルIDと同一で、通知先はそのチャンネルになります。
 

--- a/packages/discord-bot/src/commands.ts
+++ b/packages/discord-bot/src/commands.ts
@@ -4,15 +4,65 @@ import { ConnpassClient } from '@connpass-discord-bot/api-client';
 
 export const commandData = new SlashCommandBuilder()
   .setName('connpass')
-  .setDescription('Manage Connpass watch jobs for this channel')
+  .setDescription('Manage Connpass feeds for this channel')
+  .addSubcommandGroup((group) =>
+    group
+      .setName('feed')
+      .setDescription('Manage feed settings for this channel')
+      .addSubcommand((sub) =>
+        sub
+          .setName('set')
+          .setDescription('Add or update feed settings for this channel')
+          .addIntegerOption((o) => o.setName('interval_sec').setDescription('Interval seconds (default 1800)').setMinValue(60))
+          .addStringOption((o) => o.setName('keywords_and').setDescription('Keywords (AND). Comma or space separated'))
+          .addStringOption((o) => o.setName('keywords_or').setDescription('Keywords (OR). Comma or space separated'))
+          .addIntegerOption((o) => o.setName('range_days').setDescription('Days from now to search (default 14)').setMinValue(1).setMaxValue(120))
+          .addStringOption((o) =>
+            o
+              .setName('location')
+              .setDescription('Filter by prefecture (autocomplete; comma/space separated)')
+              .setAutocomplete(true)
+          )
+          .addStringOption((o) => o.setName('hashtag').setDescription('Filter by hashtag (e.g. typescript, no #)'))
+          .addStringOption((o) => o.setName('owner_nickname').setDescription('Filter by owner nickname'))
+          .addStringOption((o) =>
+            o
+              .setName('order')
+              .setDescription('Sort: updated_desc | started_asc | started_desc (optional)')
+              .addChoices(
+                { name: '更新日時の降順 (updated_desc)', value: 'updated_desc' },
+                { name: '開催日時の昇順 (started_asc)', value: 'started_asc' },
+                { name: '開催日時の降順 (started_desc)', value: 'started_desc' },
+              )
+          )
+      )
+      .addSubcommand((sub) =>
+        sub
+          .setName('sort')
+          .setDescription('Change sort type/order for search results')
+          .addStringOption((o) =>
+            o
+              .setName('order')
+              .setDescription('Select sort: updated_desc | started_asc | started_desc')
+              .setRequired(true)
+              .addChoices(
+                { name: '更新日時の降順 (updated_desc)', value: 'updated_desc' },
+                { name: '開催日時の昇順 (started_asc)', value: 'started_asc' },
+                { name: '開催日時の降順 (started_desc)', value: 'started_desc' },
+              ),
+          )
+      )
+      .addSubcommand((sub) => sub.setName('status').setDescription('Show current feed settings for this channel'))
+      .addSubcommand((sub) => sub.setName('remove').setDescription('Remove feed settings for this channel'))
+      .addSubcommand((sub) => sub.setName('run').setDescription('Run once immediately'))
+  )
   .addSubcommand((sub) =>
     sub
-      .setName('set')
-      .setDescription('Add or update a watch for this channel')
-      .addIntegerOption((o) => o.setName('interval_sec').setDescription('Interval seconds (default 1800)').setMinValue(60))
+      .setName('report')
+      .setDescription('Generate a consolidated report and post it to this channel')
       .addStringOption((o) => o.setName('keywords_and').setDescription('Keywords (AND). Comma or space separated'))
       .addStringOption((o) => o.setName('keywords_or').setDescription('Keywords (OR). Comma or space separated'))
-      .addIntegerOption((o) => o.setName('range_days').setDescription('Days from now to search (default 14)').setMinValue(1).setMaxValue(90))
+      .addIntegerOption((o) => o.setName('range_days').setDescription('Days from now to search (default 30)').setMinValue(1).setMaxValue(120))
       .addStringOption((o) =>
         o
           .setName('location')
@@ -21,26 +71,17 @@ export const commandData = new SlashCommandBuilder()
       )
       .addStringOption((o) => o.setName('hashtag').setDescription('Filter by hashtag (e.g. typescript, no #)'))
       .addStringOption((o) => o.setName('owner_nickname').setDescription('Filter by owner nickname'))
-  )
-  .addSubcommand((sub) =>
-    sub
-      .setName('sort')
-      .setDescription('Change sort type/order for search results')
       .addStringOption((o) =>
         o
           .setName('order')
-          .setDescription('Select sort: updated_desc | started_asc | started_desc')
-          .setRequired(true)
+          .setDescription('Sort: updated_desc | started_asc | started_desc (default started_asc)')
           .addChoices(
             { name: '更新日時の降順 (updated_desc)', value: 'updated_desc' },
             { name: '開催日時の昇順 (started_asc)', value: 'started_asc' },
             { name: '開催日時の降順 (started_desc)', value: 'started_desc' },
-          ),
+          )
       )
   )
-  .addSubcommand((sub) => sub.setName('status').setDescription('Show current watch settings for this channel'))
-  .addSubcommand((sub) => sub.setName('remove').setDescription('Remove watch for this channel'))
-  .addSubcommand((sub) => sub.setName('run').setDescription('Run watch once immediately'))
   .addSubcommandGroup((group) =>
     group
       .setName('user')
@@ -128,6 +169,8 @@ export async function handleCommand(
     const keywordsOrRaw = interaction.options.getString('keywords_or') ?? '';
     const rangeDays = interaction.options.getInteger('range_days') ?? 14;
     const locationRaw = interaction.options.getString('location') ?? '';
+    const orderOpt = interaction.options.getString('order') as 'updated_desc' | 'started_asc' | 'started_desc' | null;
+    const order = orderOpt === 'updated_desc' ? 1 : orderOpt === 'started_asc' ? 2 : orderOpt === 'started_desc' ? 3 : undefined;
     const prefectures = locationRaw
       .split(/[,\s]+/)
       .map((s) => s.trim())
@@ -155,12 +198,24 @@ export async function handleCommand(
       prefecture: prefectures.length > 0 ? prefectures : undefined,
       hashTag,
       ownerNickname,
+      order,
     } as const;
 
     await manager.upsert(config);
     await scheduler.restart(jobId);
     await interaction.reply({
-      content: `OK: watching this channel.\n- keywords(and): ${tokensAnd.join(', ') || '(none)'}\n- keywords(or): ${tokensOr.join(', ') || '(none)'}\n- rangeDays: ${rangeDays}\n- intervalSec: ${intervalSec}\n- hashtag: ${hashTag ?? '(none)'}\n- prefecture: ${prefectures.join(', ') || '(none)'}\n- owner_nickname: ${ownerNickname ?? '(none)'}`,
+      content:
+        `設定を更新しました (/connpass feed set)\n` +
+        `- keywords(and): ${tokensAnd.join(', ') || '(none)'}\n` +
+        `- keywords(or): ${tokensOr.join(', ') || '(none)'}\n` +
+        `- rangeDays: ${rangeDays}\n` +
+        `- intervalSec: ${intervalSec}\n` +
+        `- hashtag: ${hashTag ?? '(none)'}\n` +
+        `- prefecture: ${prefectures.join(', ') || '(none)'}\n` +
+        `- owner_nickname: ${ownerNickname ?? '(none)'}\n` +
+        (order != null
+          ? `- order: ${order === 1 ? '更新日時の降順 (updated_desc)' : order === 2 ? '開催日時の昇順 (started_asc)' : '開催日時の降順 (started_desc)'}\n`
+          : ''),
       ephemeral: true,
     });
     return;
@@ -185,30 +240,29 @@ export async function handleCommand(
     // restart to apply immediately
     await scheduler.restart(jobId);
     const label = order === 1 ? '更新日時の降順 (updated_desc)' : order === 2 ? '開催日時の昇順 (started_asc)' : '開催日時の降順 (started_desc)';
-    await interaction.reply({ content: `OK: sort updated to: ${label}`, ephemeral: true });
+    await interaction.reply({ content: `並び順を更新しました(/connpass feed sort) \n - order: ${ label } `, ephemeral: true });
     return;
   }
 
   if (sub === 'status') {
     const job = await manager.get(jobId);
     if (!job) {
-      await interaction.reply({ content: 'No watch configured for this channel.', ephemeral: true });
+      await interaction.reply({ content: 'No feed configured for this channel.', ephemeral: true });
       return;
     }
     await interaction.reply({
       content:
-        `Watch status:\n` +
-        `- keywords(and): ${(job.keyword ?? []).join(', ') || '(none)'}\n` +
-        `- keywords(or): ${(job.keywordOr ?? []).join(', ') || '(none)'}\n` +
-        `- rangeDays: ${job.rangeDays}\n` +
-        `- intervalSec: ${job.intervalSec}\n` +
-        `- hashtag: ${job.hashTag ?? '(none)'}\n` +
-        `- owner_nickname: ${job.ownerNickname ?? '(none)'}\n` +
-        `- order: ${job.order ?? 2} ` +
-        `(${(job.order ?? 2) === 1 ? 'updated_desc' : (job.order ?? 2) === 2 ? 'started_asc' : 'started_desc'})\n` +
-        `- prefecture: ${(job.prefecture ?? []).join(', ') || '(none)'}\n` +
-        `- lastRunAt: ${job.state.lastRunAt ? new Date(job.state.lastRunAt).toLocaleString() : '(never)'}\n` +
-        `- lastEventUpdatedAt: ${job.state.lastEventUpdatedAt ?? '(none)'}\n`,
+        `監視設定(/connpass feed status) \n` +
+        `- keywords(and): ${ (job.keyword ?? []).join(', ') || '(none)' } \n` +
+        `- keywords(or): ${ (job.keywordOr ?? []).join(', ') || '(none)' } \n` +
+        `- rangeDays: ${ job.rangeDays } \n` +
+        `- intervalSec: ${ job.intervalSec } \n` +
+        `- hashtag: ${ job.hashTag ?? '(none)' } \n` +
+        `- owner_nickname: ${ job.ownerNickname ?? '(none)' } \n` +
+        `- order: ${ (job.order ?? 2) === 1 ? '更新日時の降順 (updated_desc)' : (job.order ?? 2) === 2 ? '開催日時の昇順 (started_asc)' : '開催日時の降順 (started_desc)' } \n` +
+        `- prefecture: ${ (job.prefecture ?? []).join(', ') || '(none)' } \n` +
+        `- lastRunAt: ${ job.state.lastRunAt ? new Date(job.state.lastRunAt).toLocaleString() : '(never)' } \n` +
+        `- lastEventUpdatedAt: ${ job.state.lastEventUpdatedAt ?? '(none)' } \n`,
       ephemeral: true,
     });
     return;
@@ -217,16 +271,173 @@ export async function handleCommand(
   if (sub === 'remove') {
     await scheduler.stop(jobId);
     await manager.remove(jobId);
-    await interaction.reply({ content: 'Removed watch for this channel.', ephemeral: true });
+    await interaction.reply({ content: '監視を削除しました (/connpass feed remove)', ephemeral: true });
     return;
   }
 
   if (sub === 'run') {
     try {
+      const existing = await manager.get(jobId);
       const res = await manager.runOnce(jobId);
-      await interaction.reply({ content: `Ran. Found ${res.events.length} events matching current filters.`, ephemeral: true });
+      const keywordsAnd = existing?.keyword ?? [];
+      const keywordsOr = existing?.keywordOr ?? [];
+      const rangeDays = existing?.rangeDays ?? 14;
+      const intervalSec = existing?.intervalSec ?? 1800;
+      const hashTag = existing?.hashTag ?? undefined;
+      const ownerNickname = existing?.ownerNickname ?? undefined;
+      const prefecture = existing?.prefecture ?? [];
+      const order = existing?.order ?? 2;
+      const orderLabel = order === 1 ? '更新日時の降順 (updated_desc)' : order === 2 ? '開催日時の昇順 (started_asc)' : '開催日時の降順 (started_desc)';
+
+      await interaction.reply({
+        content:
+          `手動実行しました(/connpass feed run) \n` +
+          `- 検索一致: ${ res.events.length } 件（通知は新着のみ）\n` +
+          `- keywords(and): ${ keywordsAnd.join(', ') || '(none)' } \n` +
+          `- keywords(or): ${ keywordsOr.join(', ') || '(none)' } \n` +
+          `- rangeDays: ${ rangeDays } \n` +
+          `- intervalSec: ${ intervalSec } \n` +
+          `- hashtag: ${ hashTag ?? '(none)' } \n` +
+          `- owner_nickname: ${ ownerNickname ?? '(none)' } \n` +
+          `- order: ${ orderLabel } \n` +
+          `- prefecture: ${ prefecture.join(', ') || '(none)' } `,
+        ephemeral: true,
+      });
     } catch (e: any) {
-      await interaction.reply({ content: `Error: ${e?.message ?? e}`, ephemeral: true });
+      await interaction.reply({ content: `Error: ${ e?.message ?? e } `, ephemeral: true });
+    }
+    return;
+  }
+
+  if (sub === 'report') {
+    // Broader defaults and consolidated posting
+    const keywordsAndRaw = interaction.options.getString('keywords_and') ?? '';
+    const keywordsOrRaw = interaction.options.getString('keywords_or') ?? '';
+    const rangeDays = interaction.options.getInteger('range_days') ?? 30;
+    const locationRaw = interaction.options.getString('location') ?? '';
+    const orderOpt = interaction.options.getString('order') as 'updated_desc' | 'started_asc' | 'started_desc' | null;
+    const order = orderOpt === 'updated_desc' ? 1 : orderOpt === 'started_desc' ? 3 : 2; // default started_asc -> 2
+    const prefectures = locationRaw
+      .split(/[,\s]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const hashTagOpt = interaction.options.getString('hashtag') ?? undefined;
+    const hashTag = hashTagOpt ? hashTagOpt.replace(/^#/, '').trim() || undefined : undefined;
+    const ownerNickname = interaction.options.getString('owner_nickname') ?? undefined;
+
+    const tokensAnd = keywordsAndRaw
+      .split(/[,\s]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const tokensOr = keywordsOrRaw
+      .split(/[,\s]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const now = new Date();
+    const ymd = (d: Date) => `${ d.getFullYear() } -${ String(d.getMonth() + 1).padStart(2, '0') } -${ String(d.getDate()).padStart(2, '0') } `;
+    const from = ymd(now);
+    const toDate = new Date(now);
+    toDate.setDate(now.getDate() + rangeDays);
+    const to = ymd(toDate);
+
+    // Build params similar to JobManager but ad-hoc
+    const params: any = { ymdFrom: from, ymdTo: to, order };
+    if (tokensAnd.length) params.keyword = tokensAnd;
+    if (tokensOr.length) params.keywordOr = tokensOr;
+    if (prefectures.length) params.prefecture = prefectures;
+    if (ownerNickname) params.ownerNickname = ownerNickname;
+
+    await interaction.deferReply();
+    try {
+      // Fetch all pages to consolidate
+      const resp = await api.getAllEvents(params);
+      let events = resp.events;
+      if (hashTag) {
+        const norm = (s?: string) => (s ? s.trim().replace(/^#/, '').toLowerCase() : '');
+        const wanted = norm(hashTag);
+        events = events.filter((e) => norm(e.hashTag) === wanted);
+      }
+
+      if (events.length === 0) {
+        await interaction.editReply('レポート: 該当イベントはありませんでした。');
+        return;
+      }
+
+      // Sort again if needed to enforce label
+      const orderVal = order;
+      const toDateTime = (s?: string) => {
+        if (!s) return undefined;
+        const d = new Date(s);
+        return Number.isNaN(d.getTime()) ? undefined : d;
+      };
+      if (orderVal === 2) {
+        events.sort((a, b) => {
+          const sa = toDateTime(a.startedAt);
+          const sb = toDateTime(b.startedAt);
+          if (sa && sb) return sa.getTime() - sb.getTime();
+          if (sa && !sb) return -1;
+          if (!sa && sb) return 1;
+          return a.title.localeCompare(b.title);
+        });
+      } else if (orderVal === 3) {
+        events.sort((a, b) => {
+          const sa = toDateTime(a.startedAt);
+          const sb = toDateTime(b.startedAt);
+          if (sa && sb) return sb.getTime() - sa.getTime();
+          if (sa && !sb) return -1;
+          if (!sa && sb) return 1;
+          return a.title.localeCompare(b.title);
+        });
+      } else {
+        events.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      }
+
+      const hhmm = (d: Date) => `${ String(d.getHours()).padStart(2, '0') }:${ String(d.getMinutes()).padStart(2, '0') } `;
+      const ymd2 = (d: Date) => `${ d.getFullYear() } /${String(d.getMonth() + 1).padStart(2, '0')}/${ String(d.getDate()).padStart(2, '0') } `;
+      const header = [
+        `レポート(${ events.length }件)`,
+        `期間: ${ from } 〜 ${ to } `,
+        `条件: keywords(and) = ${ tokensAnd.join(', ') || '(none)' } | keywords(or)=${ tokensOr.join(', ') || '(none)' } | hashtag=${ hashTag ?? '(none)' } | prefecture=${ prefectures.join(', ') || '(none)' } | owner=${ ownerNickname ?? '(none)' } | order=${ orderVal === 1 ? 'updated_desc' : orderVal === 2 ? 'started_asc' : 'started_desc' } `,
+        '',
+      ];
+
+      const lines: string[] = [];
+      for (const e of events) {
+        const s = toDateTime(e.startedAt);
+        const t = toDateTime(e.endedAt);
+        const time = s ? t ? `${ ymd2(s) } ${ hhmm(s) } -${ hhmm(t) } ` : `${ ymd2(s) } ${ hhmm(s) } ` : '';
+        const head = time ? `${ time } ` : '';
+        const group = e.groupTitle ? ` [${ e.groupTitle }]` : '';
+        lines.push(`- ${ head }${ e.title }${ group } ${ e.url } `);
+      }
+
+      // Chunking to respect Discord 2000 char limit
+      const chunks: string[] = [];
+      const maxLen = 1900; // leave headroom
+      let buf = header.join('\n');
+      for (const line of lines) {
+        if ((buf + line + '\n').length > maxLen) {
+          chunks.push(buf);
+          buf = '';
+        }
+        buf += line + '\n';
+      }
+      if (buf.trim().length) chunks.push(buf.trimEnd());
+
+      if (chunks.length === 0) {
+        await interaction.editReply('レポート: 生成に失敗しました');
+        return;
+      }
+
+      // Send first chunk as the reply, rest as follow-ups
+      await interaction.editReply(chunks[0]);
+      for (let i = 1; i < chunks.length; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await interaction.followUp(chunks[i]);
+      }
+    } catch (e: any) {
+      await interaction.editReply(`エラー: ${ e?.message ?? e } `);
     }
     return;
   }
@@ -234,7 +445,7 @@ export async function handleCommand(
   if (sub === 'today') {
     const user = await userManager.find(interaction.user.id);
     if (!user) {
-      await interaction.reply({ content: 'Your connpass nickname is not registered. Use `/connpass user register` first.', ephemeral: true });
+      await interaction.reply({ content: 'Your connpass nickname is not registered. Use `/ connpass user register` first.', ephemeral: true });
       return;
     }
 
@@ -243,7 +454,7 @@ export async function handleCommand(
     const yyyy = now.getFullYear();
     const mm = String(now.getMonth() + 1).padStart(2, '0');
     const dd = String(now.getDate()).padStart(2, '0');
-    const ymd = `${yyyy}${mm}${dd}`;
+    const ymd = `${ yyyy }${ mm }${ dd } `;
     const resp = await api.searchEvents({ nickname: user.connpassNickname, ymd: [ymd] });
 
     if (resp.events.length === 0) {
@@ -256,7 +467,7 @@ export async function handleCommand(
       const d = new Date(s);
       return Number.isNaN(d.getTime()) ? undefined : d;
     };
-    const hhmm = (d: Date) => `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+    const hhmm = (d: Date) => `${ String(d.getHours()).padStart(2, '0') }:${ String(d.getMinutes()).padStart(2, '0') } `;
 
     const sorted = [...resp.events].sort((a, b) => {
       const sa = toDate(a.startedAt);
@@ -270,12 +481,12 @@ export async function handleCommand(
     const lines = sorted.map((e) => {
       const s = toDate(e.startedAt);
       const t = toDate(e.endedAt);
-      const time = s ? t ? `${hhmm(s)}-${hhmm(t)}` : `${hhmm(s)}` : '';
-      const head = time ? `${time} ` : '';
-      return `- ${head}${e.title} ${e.url}`;
+      const time = s ? t ? `${ hhmm(s) } -${ hhmm(t) } ` : `${ hhmm(s) } ` : '';
+      const head = time ? `${ time } ` : '';
+      return `- ${ head }${ e.title } ${ e.url } `;
     });
 
-    await interaction.reply({ content: `Your schedule for today:\n${lines.join('\n')}`, ephemeral: true });
+    await interaction.reply({ content: `Your schedule for today: \n${ lines.join('\n') } `, ephemeral: true });
     return;
   }
 }


### PR DESCRIPTION
 - Generate consolidated event report with broader defaults
 - Defaults: range_days=30, order=started_asc       
 - Supports keywords_and, keywords_or, location(autocomplete), hashtag, owner_nickname, order       
 - Fetch all pages via api-client getAllEvents and chunk messages under 2000 chars       
 - Files: packages/discord-bot/src/commands.ts       
 - Files: packages/discord-bot/src/commands.ts