### PR TITLE
feat: イベント通知にタイトルを表示

### DIFF
--- a/packages/discord-bot/src/sink.ts
+++ b/packages/discord-bot/src/sink.ts
@@ -189,7 +189,7 @@ export class DiscordSink implements JobSink {
 
       // send sequentially to preserve order
       // eslint-disable-next-line no-await-in-loop
-      await channel.send({ embeds: [embed], components: rows, files });
+      await channel.send({ content: `**${e.title}**`, embeds: [embed], components: rows, files });
     }
   }
 


### PR DESCRIPTION
Discordの通知で「画像を送信しました」と表示される問題を修正しました。
`channel.send` に `content` プロパティを追加し、イベントのタイトルをメッセージ本文として表示するようにしました。 これにより、プッシュ通知などでもイベントのタイトルが確認できるようになります。