### PR TITLE
feat(job): allow configuring scheduler options for in-process runner

### DIFF
--- a/packages/job/src/application/JobScheduler.ts
+++ b/packages/job/src/application/JobScheduler.ts
@@ -4,13 +4,15 @@ import { JobManager } from './JobManager';
 type Timers = { feed?: NodeJS.Timeout; report?: NodeJS.Timeout };
 type ScheduleMode = 'interval' | 'scheduled'; // 実行モード
 
+export type JobSchedulerOptions = { mode?: ScheduleMode };
+
 export class JobScheduler {
   private timers = new Map<string, Timers>();
   private nextExecutionCache = new Map<string, number>(); // メモリキャッシュ
   private executionChecker?: NodeJS.Timeout;
   private readonly mode: ScheduleMode;
 
-  constructor(private readonly manager: JobManager, options?: { mode?: ScheduleMode }) {
+  constructor(private readonly manager: JobManager, options?: JobSchedulerOptions) {
     this.mode = options?.mode || 'scheduled'; // デフォルトは新方式
 
     if (this.mode === 'scheduled') {

--- a/packages/job/src/index.ts
+++ b/packages/job/src/index.ts
@@ -1,6 +1,7 @@
 import { ConnpassClient } from '@connpass-discord-bot/api-client';
 import { JobManager } from './application/JobManager';
 import { JobScheduler } from './application/JobScheduler';
+import type { JobSchedulerOptions } from './application/JobScheduler';
 import { UserManager } from './application/UserManager';
 import { InMemoryJobStore } from './infrastructure/InMemoryJobStore';
 import { InMemoryUserStore } from './infrastructure/InMemoryUserStore';
@@ -32,6 +33,8 @@ export {
   type UserStore,
 };
 
+export type { JobSchedulerOptions } from './application/JobScheduler';
+
 // A basic sink that logs to console; consumers (e.g., Discord bot) should implement their own sink.
 export class ConsoleSink implements JobSink {
   handleNewEvents(payload: NewEventsPayload): void {
@@ -50,12 +53,13 @@ export function createInProcessRunner(opts: {
   apiKey: string;
   sink?: JobSink;
   store?: JobStore;
+  schedulerOptions?: JobSchedulerOptions;
 }) {
   const client = new ConnpassClient({ apiKey: opts.apiKey });
   const store = opts.store ?? new InMemoryJobStore();
   const sink = opts.sink ?? new ConsoleSink();
   const manager = new JobManager(client, store, sink);
-  const scheduler = new JobScheduler(manager);
+  const scheduler = new JobScheduler(manager, opts.schedulerOptions);
   return { client, manager, scheduler };
 }
 


### PR DESCRIPTION
## Summary
- export a JobSchedulerOptions type from the job package
- allow createInProcessRunner to accept scheduler options and forward them to JobScheduler
- re-export JobSchedulerOptions alongside the rest of the public API so downstream packages can import it cleanly

## Testing
- pnpm --filter @connpass-discord-bot/api-client build
- pnpm --filter @connpass-discord-bot/job build
- pnpm --filter @connpass-discord-bot/discord-bot build

------
https://chatgpt.com/codex/tasks/task_e_68da73a837588330ac3c9ca133a2d54a