### PR TITLE
feat: Implement AI model management commands for Discord bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,10 @@ DISCORD_APPLICATION_ID=
 # Connpass API
 CONNPASS_API_KEY=
 
-# OpenAI (AIアシスタント機能用、オプション)
+# AI Provider API Keys (使用するプロバイダーのみ設定)
 OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_GENERATIVE_AI_API_KEY=
 
 # データ保存先 (オプション)
 JOB_STORE_DIR=./data

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ DISCORD_APPLICATION_ID=your_application_id
 # Connpass API
 CONNPASS_API_KEY=your_connpass_api_key
 
-# OpenAI（AIアシスタント機能を使う場合）
+# AI Provider API Keys（使用するプロバイダーのみ設定）
 OPENAI_API_KEY=sk-...
+ANTHROPIC_API_KEY=sk-ant-...
+GOOGLE_GENERATIVE_AI_API_KEY=...
 
 # オプション
 JOB_STORE_DIR=./data
@@ -67,6 +69,9 @@ pnpm --filter @connpass-discord-bot/discord-bot start
 | `/connpass feed remove` | フィード削除 |
 | `/connpass feed run` | 手動実行 |
 | `/connpass user register` | ニックネーム登録 |
+| `/connpass model set` | チャンネルのAIモデル設定 |
+| `/connpass model status` | モデル設定確認 |
+| `/connpass model reset` | モデル設定リセット |
 | `/connpass today` | 今日のイベント |
 
 ### フィードの規模フィルタ
@@ -86,6 +91,62 @@ Botにメンションして質問：
 @Bot Feedの設定して
 ```
 
+**💡 会話のコンテキストについて**
+
+- **イベント情報の保持**: スレッドの元となったイベント詳細を常に把握しています。
+- **直近の会話履歴**: 直近のメッセージを認識して回答します。
+- **履歴の自動取得**: 文脈が不足している場合、AIが必要に応じて過去の会話ログを自動的に参照します。
+
+## AIモデル設定
+
+AIモデルはチャンネルごとに設定可能です。OpenAI、Claude、Geminiに対応しています。
+
+### グローバル設定（デフォルト）
+
+`apps/discord-bot/config/ai-models.json` でデフォルトモデルを設定：
+
+```json
+{
+  "agent": {
+    "provider": "openai",
+    "model": "gpt-4o-mini"
+  },
+  "summarizer": {
+    "provider": "openai",
+    "model": "gpt-4o-mini"
+  },
+  "allowedModels": {
+    "openai": ["gpt-4o-mini"],
+    "anthropic": ["claude-4-5-haiku"],
+    "google": ["gemini-2.5-flash"]
+  }
+}
+```
+
+- `agent`: AIアシスタント（会話）で使用するモデル
+- `summarizer`: イベント要約で使用するモデル
+- `allowedModels`: 使用可能なモデルのホワイトリスト
+
+### チャンネルごとの設定
+
+`/connpass model set` コマンドでチャンネルごとにモデルを設定できます：
+
+```
+/connpass model set type:エージェント（会話） provider:anthropic model:claude-4-5-haiku
+/connpass model set type:要約 provider:openai model:gpt-4o-mini
+```
+
+チャンネル設定がない場合は、グローバル設定が使用されます。
+`/connpass model status` で現在の設定を確認できます。
+
+### 対応プロバイダー
+
+| プロバイダー | 環境変数 | 推奨モデル |
+|-------------|---------|-----------|
+| OpenAI | `OPENAI_API_KEY` | gpt-4o-mini |
+| Anthropic (Claude) | `ANTHROPIC_API_KEY` | claude-3-5-haiku-20241022 |
+| Google (Gemini) | `GOOGLE_GENERATIVE_AI_API_KEY` | gemini-1.5-flash |
+
 ## 構成
 
 ```
@@ -102,7 +163,7 @@ packages/
 
 - **Runtime**: Node.js 22+
 - **Discord**: discord.js
-- **AI**: Mastra + OpenAI GPT-4o-mini
+- **AI**: Mastra + Vercel AI SDK (OpenAI / Claude / Gemini)
 - **API**: @kajidog/connpass-api-client
 
 ## ライセンス

--- a/apps/discord-bot/config/ai-models.json
+++ b/apps/discord-bot/config/ai-models.json
@@ -1,0 +1,41 @@
+{
+  "agent": {
+    "provider": "openai",
+    "model": "gpt-4o-mini"
+  },
+  "summarizer": {
+    "provider": "openai",
+    "model": "gpt-4o-mini"
+  },
+  "allowedModels": {
+    "openai": [
+      "gpt-5.2-pro",
+      "gpt-5.2",
+      "gpt-5.1",
+      "gpt-5",
+      "gpt-5-mini",
+      "gpt-4.1",
+      "gpt-4.1-mini",
+      "gpt-4o",
+      "gpt-4o-mini"
+    ],
+    "anthropic": [
+      "claude-opus-4-5",
+      "claude-sonnet-4-5",
+      "claude-haiku-4-5",
+      "claude-opus-4-1",
+      "claude-sonnet-4-0",
+      "claude-3-7-sonnet-latest",
+      "claude-3-5-haiku-latest"
+    ],
+    "google": [
+      "gemini-3-pro-preview",
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+      "gemini-2.5-flash-lite",
+      "gemini-2.0-flash",
+      "gemini-1.5-pro",
+      "gemini-1.5-flash"
+    ]
+  }
+}

--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -11,6 +11,8 @@
     "register": "node dist/registerCommands.js"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^2.0.0",
+    "@ai-sdk/google": "^2.0.0",
     "@ai-sdk/openai": "^2.0.53",
     "@connpass-discord-bot/core": "workspace:*",
     "@connpass-discord-bot/feed-worker": "workspace:*",

--- a/apps/discord-bot/src/agent/conversation-tools.ts
+++ b/apps/discord-bot/src/agent/conversation-tools.ts
@@ -1,0 +1,185 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+import type { Message, TextChannel, ThreadChannel } from 'discord.js';
+import type { ProgressEmbed } from './progress-embed.js';
+
+/**
+ * メッセージ概要の型
+ */
+export interface MessageSummary {
+  index: number;
+  author: string;
+  summary: string;
+  isBot: boolean;
+  timestamp: string;
+}
+
+/**
+ * メッセージ詳細の型
+ */
+export interface MessageDetail {
+  author: string;
+  content: string;
+  timestamp: string;
+  isBot: boolean;
+  hasEmbed: boolean;
+  embedTitle?: string;
+}
+
+/**
+ * スレッド/チャンネルのメッセージをキャッシュ
+ */
+let cachedMessages: Message[] = [];
+let cachedChannelId: string | null = null;
+
+/**
+ * メッセージキャッシュを設定（ハンドラーから呼び出し）
+ */
+export function setMessageCache(channelId: string, messages: Message[]): void {
+  cachedChannelId = channelId;
+  cachedMessages = messages;
+}
+
+/**
+ * メッセージキャッシュをクリア
+ */
+export function clearMessageCache(): void {
+  cachedChannelId = null;
+  cachedMessages = [];
+}
+
+/**
+ * メッセージを要約形式に変換（先頭50文字）
+ */
+function summarizeMessage(msg: Message): string {
+  if (msg.embeds.length > 0 && msg.embeds[0].title) {
+    return `[Embed: ${msg.embeds[0].title}]`;
+  }
+  const content = msg.content.replace(/<@!?\d+>/g, '@user').trim();
+  if (!content) return '[添付/リアクションのみ]';
+  return content.length > 50 ? content.slice(0, 50) + '...' : content;
+}
+
+/**
+ * 会話概要取得ツール
+ * 直近のメッセージ一覧を概要形式で返す
+ */
+export const getConversationSummaryTool = createTool({
+  id: 'getConversationSummary',
+  description: 'スレッド/チャンネルの会話概要を取得。誰が何について話したかの一覧。詳細が必要な場合は getMessage を使用。',
+  inputSchema: z.object({
+    limit: z.number().min(1).max(20).default(10).describe('取得するメッセージ数（デフォルト10件）'),
+  }),
+  outputSchema: z.object({
+    messages: z.array(z.object({
+      index: z.number(),
+      author: z.string(),
+      summary: z.string(),
+      isBot: z.boolean(),
+      timestamp: z.string(),
+    })),
+    totalCount: z.number(),
+  }),
+  execute: async ({ context, runtimeContext }) => {
+    const progress = runtimeContext?.get('progress') as ProgressEmbed | undefined;
+    
+    // ツール使用開始を記録
+    const callId = progress?.addToolCall('getConversationSummary', context);
+
+    const limit = (context as { limit?: number }).limit ?? 10;
+    
+    if (cachedMessages.length === 0) {
+      if (callId) progress?.addToolResult(callId, true, '0件');
+      return {
+        messages: [],
+        totalCount: 0,
+      };
+    }
+
+    // 新しい順に取得されているので逆順にして、limit件取得
+    const targetMessages = cachedMessages.slice(0, limit).reverse();
+    
+    const summaries: MessageSummary[] = targetMessages.map((msg, idx) => ({
+      index: idx,
+      author: msg.author.displayName || msg.author.username,
+      summary: summarizeMessage(msg),
+      isBot: msg.author.bot,
+      timestamp: msg.createdAt.toISOString(),
+    }));
+
+    // 完了を記録
+    if (callId) progress?.addToolResult(callId, true, `${targetMessages.length}件取得`);
+
+    return {
+      messages: summaries,
+      totalCount: cachedMessages.length,
+    };
+  },
+});
+
+/**
+ * 特定メッセージ詳細取得ツール
+ */
+export const getMessageTool = createTool({
+  id: 'getMessage',
+  description: '指定したインデックスのメッセージ詳細を取得。getConversationSummary で取得したインデックスを使用。',
+  inputSchema: z.object({
+    index: z.number().min(0).describe('メッセージのインデックス（getConversationSummaryの結果から）'),
+  }),
+  outputSchema: z.object({
+    author: z.string(),
+    content: z.string(),
+    timestamp: z.string(),
+    isBot: z.boolean(),
+    hasEmbed: z.boolean(),
+    embedTitle: z.string().optional(),
+    embedDescription: z.string().optional(),
+  }),
+  execute: async ({ context, runtimeContext }) => {
+    const progress = runtimeContext?.get('progress') as ProgressEmbed | undefined;
+    
+    // ツール使用開始を記録
+    const callId = progress?.addToolCall('getMessage', context);
+
+    const index = (context as { index: number }).index;
+    
+    // 逆順にして取得（古い順）
+    const targetMessages = [...cachedMessages].reverse();
+    
+    if (index < 0 || index >= targetMessages.length) {
+      if (callId) progress?.addToolResult(callId, false, '見つかりません');
+      return {
+        author: 'System',
+        content: 'メッセージが見つかりません',
+        timestamp: new Date().toISOString(),
+        isBot: false,
+        hasEmbed: false,
+      };
+    }
+
+    const msg = targetMessages[index];
+    const embed = msg.embeds[0];
+
+    // 完了を記録
+    const authorName = msg.author.displayName || msg.author.username;
+    if (callId) progress?.addToolResult(callId, true, `From: ${authorName}`);
+
+    return {
+      author: authorName,
+      content: msg.content.replace(/<@!?\d+>/g, '@user').trim() || '[内容なし]',
+      timestamp: msg.createdAt.toISOString(),
+      isBot: msg.author.bot,
+      hasEmbed: msg.embeds.length > 0,
+      embedTitle: embed?.title || undefined,
+      embedDescription: embed?.description?.slice(0, 200) || undefined,
+    };
+  },
+});
+
+/**
+ * 会話コンテキストツール一覧
+ */
+export const conversationTools = {
+  getConversationSummary: getConversationSummaryTool,
+  getMessage: getMessageTool,
+};

--- a/apps/discord-bot/src/ai/index.ts
+++ b/apps/discord-bot/src/ai/index.ts
@@ -1,0 +1,9 @@
+export {
+  getModel,
+  loadAIConfig,
+  getAIConfig,
+  getModelConfigForChannel,
+  hasApiKey,
+  validateModel,
+  clearConfigCache,
+} from './model-provider.js';

--- a/apps/discord-bot/src/ai/model-provider.ts
+++ b/apps/discord-bot/src/ai/model-provider.ts
@@ -1,0 +1,182 @@
+import { openai } from '@ai-sdk/openai';
+import { anthropic } from '@ai-sdk/anthropic';
+import { google } from '@ai-sdk/google';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import type { AIProvider, ModelConfig, AIModelsConfig } from '@connpass-discord-bot/core';
+import type { LanguageModel } from 'ai';
+
+/**
+ * 許可されたモデルかどうかをバリデーション
+ */
+export function validateModel(
+  config: AIModelsConfig,
+  provider: AIProvider,
+  model: string
+): boolean {
+  const allowed = config.allowedModels[provider];
+  return allowed?.includes(model) ?? false;
+}
+
+/**
+ * プロバイダーとモデル名からモデルインスタンスを取得
+ * @throws APIキーが設定されていない場合はエラー
+ */
+export function getModel(config: ModelConfig): LanguageModel {
+  const { provider, model } = config;
+
+  // APIキーの存在チェック
+  if (!hasApiKey(provider)) {
+    const envVarName = getApiKeyEnvVar(provider);
+    throw new Error(
+      `${provider} のAPIキーが設定されていません。環境変数 ${envVarName} を設定してください。`
+    );
+  }
+
+  switch (provider) {
+    case 'openai':
+      return openai(model) as unknown as LanguageModel;
+    case 'anthropic':
+      return anthropic(model) as unknown as LanguageModel;
+    case 'google':
+      return google(model) as unknown as LanguageModel;
+    default:
+      throw new Error(`Unknown provider: ${provider}`);
+  }
+}
+
+/**
+ * プロバイダーに対応するAPIキーの環境変数名を取得
+ */
+function getApiKeyEnvVar(provider: AIProvider): string {
+  switch (provider) {
+    case 'openai':
+      return 'OPENAI_API_KEY';
+    case 'anthropic':
+      return 'ANTHROPIC_API_KEY';
+    case 'google':
+      return 'GOOGLE_GENERATIVE_AI_API_KEY';
+    default:
+      return 'UNKNOWN';
+  }
+}
+
+/**
+ * 設定ファイルのデフォルトパス
+ */
+const DEFAULT_CONFIG_PATH = './config/ai-models.json';
+
+/**
+ * デフォルトのAI設定（設定ファイルがない場合に使用）
+ */
+const DEFAULT_AI_CONFIG: AIModelsConfig = {
+  agent: {
+    provider: 'openai',
+    model: 'gpt-4o-mini',
+  },
+  summarizer: {
+    provider: 'openai',
+    model: 'gpt-4o-mini',
+  },
+  allowedModels: {
+    openai: ['gpt-5.2-pro', 'gpt-5.2', 'gpt-5.1', 'gpt-5', 'gpt-5-mini', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4o', 'gpt-4o-mini'],
+    anthropic: ['claude-opus-4-5', 'claude-sonnet-4-5', 'claude-haiku-4-5', 'claude-opus-4-1', 'claude-sonnet-4-0', 'claude-3-7-sonnet-latest', 'claude-3-5-haiku-latest'],
+    google: ['gemini-3-pro-preview', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite', 'gemini-2.0-flash', 'gemini-1.5-pro', 'gemini-1.5-flash'],
+  },
+};
+
+/**
+ * 設定ファイルを読み込み、バリデーションを実行
+ * 設定ファイルがない場合はデフォルト設定を使用
+ */
+export function loadAIConfig(configPath?: string): AIModelsConfig {
+  const path = configPath || process.env.AI_CONFIG_PATH || DEFAULT_CONFIG_PATH;
+  const resolvedPath = resolve(path);
+
+  if (!existsSync(resolvedPath)) {
+    console.warn(`[AI Config] Config file not found: ${resolvedPath}, using defaults`);
+    return structuredClone(DEFAULT_AI_CONFIG);
+  }
+
+  try {
+    const content = readFileSync(resolvedPath, 'utf-8');
+    const config: AIModelsConfig = JSON.parse(content);
+
+    // バリデーション
+    if (!validateModel(config, config.agent.provider, config.agent.model)) {
+      throw new Error(
+        `Invalid agent model: ${config.agent.provider}/${config.agent.model}. Check allowedModels in config.`
+      );
+    }
+    if (!validateModel(config, config.summarizer.provider, config.summarizer.model)) {
+      throw new Error(
+        `Invalid summarizer model: ${config.summarizer.provider}/${config.summarizer.model}. Check allowedModels in config.`
+      );
+    }
+
+    return config;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      console.error(`[AI Config] Invalid JSON in config file: ${resolvedPath}`);
+      console.warn('[AI Config] Using default config');
+      return structuredClone(DEFAULT_AI_CONFIG);
+    }
+    throw error;
+  }
+}
+
+/**
+ * チャンネルごとのモデル設定を取得
+ * チャンネル設定がない場合はグローバル設定を使用
+ */
+export function getModelConfigForChannel(
+  config: AIModelsConfig,
+  type: 'agent' | 'summarizer',
+  channelConfig?: { agent?: ModelConfig; summarizer?: ModelConfig } | null
+): ModelConfig {
+  // チャンネル設定があればそれを優先
+  if (channelConfig?.[type]) {
+    return channelConfig[type]!;
+  }
+
+  // なければグローバル設定を使用
+  return config[type];
+}
+
+/**
+ * プロバイダーに対応するAPIキーが設定されているかチェック
+ */
+export function hasApiKey(provider: AIProvider): boolean {
+  switch (provider) {
+    case 'openai':
+      return !!process.env.OPENAI_API_KEY;
+    case 'anthropic':
+      return !!process.env.ANTHROPIC_API_KEY;
+    case 'google':
+      return !!process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+    default:
+      return false;
+  }
+}
+
+/**
+ * AI設定のシングルトンインスタンス
+ */
+let cachedConfig: AIModelsConfig | null = null;
+
+/**
+ * キャッシュされた設定を取得（初回のみファイル読み込み）
+ */
+export function getAIConfig(): AIModelsConfig {
+  if (!cachedConfig) {
+    cachedConfig = loadAIConfig();
+  }
+  return cachedConfig;
+}
+
+/**
+ * 設定キャッシュをクリア（テスト用）
+ */
+export function clearConfigCache(): void {
+  cachedConfig = null;
+}

--- a/apps/discord-bot/src/commands/definitions.ts
+++ b/apps/discord-bot/src/commands/definitions.ts
@@ -104,6 +104,62 @@ export const connpassCommand = new SlashCommandBuilder()
       .addSubcommand((sub) => sub.setName('unregister').setDescription('ニックネーム登録を解除'))
   )
 
+  // /connpass model サブコマンドグループ
+  .addSubcommandGroup((group) =>
+    group
+      .setName('model')
+      .setDescription('このチャンネルのAIモデル設定を管理')
+      .addSubcommand((sub) =>
+        sub
+          .setName('set')
+          .setDescription('使用するモデルを設定')
+          .addStringOption((o) =>
+            o
+              .setName('type')
+              .setDescription('モデルの種類')
+              .setRequired(true)
+              .addChoices(
+                { name: 'エージェント（会話）', value: 'agent' },
+                { name: '要約', value: 'summarizer' }
+              )
+          )
+          .addStringOption((o) =>
+            o
+              .setName('provider')
+              .setDescription('AIプロバイダー')
+              .setRequired(true)
+              .addChoices(
+                { name: 'OpenAI', value: 'openai' },
+                { name: 'Anthropic (Claude)', value: 'anthropic' },
+                { name: 'Google (Gemini)', value: 'google' }
+              )
+          )
+          .addStringOption((o) =>
+            o
+              .setName('model')
+              .setDescription('モデル名（例: gpt-4o-mini）')
+              .setRequired(true)
+              .setAutocomplete(true)
+          )
+      )
+      .addSubcommand((sub) => sub.setName('status').setDescription('現在のモデル設定を表示'))
+      .addSubcommand((sub) => sub.setName('list').setDescription('使用可能なモデル一覧を表示'))
+      .addSubcommand((sub) =>
+        sub
+          .setName('reset')
+          .setDescription('このチャンネルのモデル設定をリセット（グローバル設定を使用）')
+          .addStringOption((o) =>
+            o
+              .setName('type')
+              .setDescription('リセットするモデルの種類（未指定の場合は全てリセット）')
+              .addChoices(
+                { name: 'エージェント（会話）', value: 'agent' },
+                { name: '要約', value: 'summarizer' }
+              )
+          )
+      )
+  )
+
   // /connpass today
   .addSubcommand((sub) => sub.setName('today').setDescription('今日参加予定のイベントを表示'))
 

--- a/apps/discord-bot/src/commands/handlers/model.ts
+++ b/apps/discord-bot/src/commands/handlers/model.ts
@@ -1,0 +1,183 @@
+import type { ChatInputCommandInteraction } from 'discord.js';
+import type { IChannelModelStore, AIProvider, ModelConfig, ChannelModelConfig } from '@connpass-discord-bot/core';
+import { getAIConfig, validateModel } from '../../ai/index.js';
+
+/**
+ * /connpass model ハンドラー
+ */
+export async function handleModelCommand(
+  interaction: ChatInputCommandInteraction,
+  channelModelStore: IChannelModelStore
+): Promise<void> {
+  const subcommand = interaction.options.getSubcommand();
+
+  switch (subcommand) {
+    case 'set':
+      await handleModelSet(interaction, channelModelStore);
+      break;
+    case 'status':
+      await handleModelStatus(interaction, channelModelStore);
+      break;
+    case 'reset':
+      await handleModelReset(interaction, channelModelStore);
+      break;
+    case 'list':
+      await handleModelList(interaction);
+      break;
+    default:
+      await interaction.reply({ content: '未知のサブコマンドです', ephemeral: true });
+  }
+}
+
+/**
+ * /connpass model set
+ */
+async function handleModelSet(
+  interaction: ChatInputCommandInteraction,
+  channelModelStore: IChannelModelStore
+): Promise<void> {
+  const type = interaction.options.getString('type', true) as 'agent' | 'summarizer';
+  const provider = interaction.options.getString('provider', true) as AIProvider;
+  const model = interaction.options.getString('model', true);
+  const channelId = interaction.channelId;
+
+  // グローバル設定を取得
+  const aiConfig = getAIConfig();
+
+  // 許可リストでバリデーション
+  if (!validateModel(aiConfig, provider, model)) {
+    const allowedModels = aiConfig.allowedModels[provider] || [];
+    await interaction.reply({
+      content: `❌ モデル \`${model}\` は許可リストにありません。\n\n**${provider}の許可モデル:**\n${allowedModels.map(m => `- \`${m}\``).join('\n')}`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  // 既存の設定を取得
+  let channelConfig = await channelModelStore.get(channelId);
+  if (!channelConfig) {
+    channelConfig = { channelId };
+  }
+
+  // 設定を更新
+  const modelConfig: ModelConfig = { provider, model };
+  if (type === 'agent') {
+    channelConfig.agent = modelConfig;
+  } else {
+    channelConfig.summarizer = modelConfig;
+  }
+
+  await channelModelStore.save(channelConfig);
+
+  const typeName = type === 'agent' ? 'エージェント（会話）' : '要約';
+  await interaction.reply({
+    content: `✅ **${typeName}モデルを設定しました**\n\nプロバイダー: ${provider}\nモデル: \`${model}\``,
+    ephemeral: true,
+  });
+}
+
+/**
+ * /connpass model status
+ */
+async function handleModelStatus(
+  interaction: ChatInputCommandInteraction,
+  channelModelStore: IChannelModelStore
+): Promise<void> {
+  const channelId = interaction.channelId;
+  const aiConfig = getAIConfig();
+  const channelConfig = await channelModelStore.get(channelId);
+
+  let message = '📊 **このチャンネルのAIモデル設定**\n\n';
+
+  // エージェント設定
+  const agentConfig = channelConfig?.agent || aiConfig.agent;
+  const agentSource = channelConfig?.agent ? '🔧 カスタム' : '🌐 デフォルト';
+  message += `**🤖 エージェント（会話）**\n`;
+  message += `├ 設定: ${agentSource}\n`;
+  message += `└ モデル: \`${agentConfig.provider}/${agentConfig.model}\`\n\n`;
+
+  // 要約設定
+  const summarizerConfig = channelConfig?.summarizer || aiConfig.summarizer;
+  const summarizerSource = channelConfig?.summarizer ? '🔧 カスタム' : '🌐 デフォルト';
+  message += `**📝 要約**\n`;
+  message += `├ 設定: ${summarizerSource}\n`;
+  message += `└ モデル: \`${summarizerConfig.provider}/${summarizerConfig.model}\`\n\n`;
+
+  message += `💡 \`/connpass model list\` で使用可能なモデル一覧を表示`;
+
+  await interaction.reply({ content: message, ephemeral: true });
+}
+
+/**
+ * /connpass model list
+ */
+async function handleModelList(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  const aiConfig = getAIConfig();
+
+  let message = '📋 **使用可能なモデル一覧**\n\n';
+
+  for (const [provider, models] of Object.entries(aiConfig.allowedModels)) {
+    message += `**${provider}**\n`;
+    message += models.map(m => `└ \`${m}\``).join('\n');
+    message += '\n\n';
+  }
+
+  message += `💡 \`/connpass model set\` でモデルを設定`;
+
+  await interaction.reply({ content: message, ephemeral: true });
+}
+
+/**
+ * /connpass model reset
+ */
+async function handleModelReset(
+  interaction: ChatInputCommandInteraction,
+  channelModelStore: IChannelModelStore
+): Promise<void> {
+  const channelId = interaction.channelId;
+  const type = interaction.options.getString('type') as 'agent' | 'summarizer' | null;
+
+  if (!type) {
+    // 全てリセット
+    await channelModelStore.delete(channelId);
+    await interaction.reply({
+      content: '✅ このチャンネルのモデル設定を全てリセットしました。グローバル設定を使用します。',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  // 特定のタイプのみリセット
+  const channelConfig = await channelModelStore.get(channelId);
+  if (!channelConfig) {
+    await interaction.reply({
+      content: '⚠️ このチャンネルには設定がありません。',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const typeName = type === 'agent' ? 'エージェント（会話）' : '要約';
+
+  if (type === 'agent') {
+    delete channelConfig.agent;
+  } else {
+    delete channelConfig.summarizer;
+  }
+
+  // 両方の設定が削除された場合はチャンネル設定自体を削除
+  if (!channelConfig.agent && !channelConfig.summarizer) {
+    await channelModelStore.delete(channelId);
+  } else {
+    await channelModelStore.save(channelConfig);
+  }
+
+  await interaction.reply({
+    content: `✅ **${typeName}モデル**をリセットしました。グローバル設定を使用します。`,
+    ephemeral: true,
+  });
+}
+

--- a/apps/discord-bot/src/interactions/autocomplete.ts
+++ b/apps/discord-bot/src/interactions/autocomplete.ts
@@ -1,5 +1,7 @@
 import type { AutocompleteInteraction } from 'discord.js';
 import { filterPrefectures } from '../data/prefectures.js';
+import { getAIConfig } from '../ai/index.js';
+import type { AIProvider } from '@connpass-discord-bot/core';
 
 /**
  * オートコンプリートハンドラー
@@ -10,6 +12,26 @@ export async function handleAutocomplete(interaction: AutocompleteInteraction): 
   if (focused.name === 'location') {
     const query = focused.value;
     const filtered = filterPrefectures(query);
+    await interaction.respond(filtered);
+    return;
+  }
+
+  if (focused.name === 'model') {
+    const provider = interaction.options.getString('provider') as AIProvider | null;
+    if (!provider) {
+      await interaction.respond([]);
+      return;
+    }
+
+    const aiConfig = getAIConfig();
+    const allowedModels = aiConfig.allowedModels[provider] || [];
+    const query = focused.value.toLowerCase();
+
+    const filtered = allowedModels
+      .filter(model => model.toLowerCase().includes(query))
+      .slice(0, 25)
+      .map(model => ({ name: model, value: model }));
+
     await interaction.respond(filtered);
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,13 @@ services:
       DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN}
       DISCORD_APPLICATION_ID: ${DISCORD_APPLICATION_ID}
       CONNPASS_API_KEY: ${CONNPASS_API_KEY}
-      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
       ENABLE_AI_AGENT: ${ENABLE_AI_AGENT:-true}
       JOB_STORE_DIR: /data
       AGENT_DATABASE_URL: file:/data/agent-memory.db
+      AI_CONFIG_PATH: ${AI_CONFIG_PATH:-}
     volumes:
       - bot-data:/data
       - ./apps:/app/apps
@@ -19,3 +22,5 @@ services:
 
 volumes:
   bot-data:
+
+

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -1,0 +1,2 @@
+// AI Model Configuration Types
+export type { AIProvider, ModelConfig, AIModelsConfig, ChannelModelConfig } from './types.js';

--- a/packages/core/src/ai/types.ts
+++ b/packages/core/src/ai/types.ts
@@ -1,0 +1,36 @@
+/**
+ * AIプロバイダーの種類
+ */
+export type AIProvider = 'openai' | 'anthropic' | 'google';
+
+/**
+ * モデル設定
+ */
+export interface ModelConfig {
+  provider: AIProvider;
+  model: string;
+}
+
+/**
+ * AI設定ファイルの構造
+ */
+export interface AIModelsConfig {
+  /** エージェント用モデル設定 */
+  agent: ModelConfig;
+  /** 要約用モデル設定 */
+  summarizer: ModelConfig;
+  /** 許可されたモデルのリスト (プロバイダーごと) */
+  allowedModels: Record<AIProvider, string[]>;
+}
+
+/**
+ * チャンネルごとのモデル設定
+ */
+export interface ChannelModelConfig {
+  /** チャンネルID */
+  channelId: string;
+  /** エージェント用モデル設定 */
+  agent?: ModelConfig;
+  /** 要約用モデル設定 */
+  summarizer?: ModelConfig;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,3 +19,7 @@ export { ORDER_MAP, DEFAULTS } from './domain/types.js';
 export type { IFeedStore } from './repositories/IFeedStore.js';
 export type { IUserStore } from './repositories/IUserStore.js';
 export type { ISummaryCacheStore } from './repositories/ISummaryCacheStore.js';
+export type { IChannelModelStore } from './repositories/IChannelModelStore.js';
+
+// AI Model Configuration
+export type { AIProvider, ModelConfig, AIModelsConfig, ChannelModelConfig } from './ai/index.js';

--- a/packages/core/src/repositories/IChannelModelStore.ts
+++ b/packages/core/src/repositories/IChannelModelStore.ts
@@ -1,0 +1,25 @@
+import type { ChannelModelConfig } from '../ai/types.js';
+
+/**
+ * チャンネルごとのモデル設定を管理するストア
+ */
+export interface IChannelModelStore {
+  /**
+   * チャンネルのモデル設定を取得
+   * @param channelId チャンネルID
+   * @returns モデル設定（存在しない場合はnull）
+   */
+  get(channelId: string): Promise<ChannelModelConfig | null>;
+
+  /**
+   * チャンネルのモデル設定を保存
+   * @param config モデル設定
+   */
+  save(config: ChannelModelConfig): Promise<void>;
+
+  /**
+   * チャンネルのモデル設定を削除
+   * @param channelId チャンネルID
+   */
+  delete(channelId: string): Promise<void>;
+}

--- a/packages/feed-worker/src/index.ts
+++ b/packages/feed-worker/src/index.ts
@@ -4,6 +4,7 @@ export { FileFeedStore } from './storage/FileFeedStore.js';
 export { InMemoryUserStore } from './storage/InMemoryUserStore.js';
 export { FileUserStore } from './storage/FileUserStore.js';
 export { FileSummaryCacheStore } from './storage/FileSummaryCacheStore.js';
+export { FileChannelModelStore } from './storage/FileChannelModelStore.js';
 
 // Executor
 export type { ISink } from './executor/ISink.js';

--- a/packages/feed-worker/src/storage/FileChannelModelStore.ts
+++ b/packages/feed-worker/src/storage/FileChannelModelStore.ts
@@ -1,0 +1,84 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { ChannelModelConfig, IChannelModelStore } from '@connpass-discord-bot/core';
+
+interface StoredData {
+  channels: Record<string, ChannelModelConfig>;
+}
+
+/**
+ * ファイルベースチャンネルモデル設定ストア
+ */
+export class FileChannelModelStore implements IChannelModelStore {
+  private filePath: string;
+  private data: StoredData | null = null;
+
+  constructor(storeDir: string) {
+    this.filePath = join(storeDir, 'channel-models.json');
+  }
+
+  private async load(): Promise<StoredData> {
+    if (this.data) return this.data;
+
+    if (!existsSync(this.filePath)) {
+      this.data = { channels: {} };
+      return this.data;
+    }
+
+    try {
+      const content = await readFile(this.filePath, 'utf-8');
+      this.data = JSON.parse(content) as StoredData;
+    } catch {
+      this.data = { channels: {} };
+    }
+
+    return this.data;
+  }
+
+  private async persist(): Promise<void> {
+    if (!this.data) return;
+
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true });
+    }
+
+    await writeFile(this.filePath, JSON.stringify(this.data, null, 2), 'utf-8');
+  }
+
+  async get(channelId: string): Promise<ChannelModelConfig | null> {
+    const data = await this.load();
+    const config = data.channels[channelId];
+    return config ? structuredClone(config) : null;
+  }
+
+  async save(config: ChannelModelConfig): Promise<void> {
+    const data = await this.load();
+    data.channels[config.channelId] = structuredClone(config);
+    await this.persist();
+  }
+
+  async delete(channelId: string): Promise<void> {
+    const data = await this.load();
+    delete data.channels[channelId];
+    await this.persist();
+  }
+
+  /**
+   * キャッシュをクリアして設定を再読み込み
+   * 外部から設定ファイルを直接編集した場合に使用
+   */
+  async reload(): Promise<void> {
+    this.data = null;
+    await this.load();
+  }
+
+  /**
+   * 全チャンネルの設定を取得
+   */
+  async getAll(): Promise<ChannelModelConfig[]> {
+    const data = await this.load();
+    return Object.values(data.channels).map(config => structuredClone(config));
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,12 @@ importers:
 
   apps/discord-bot:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^2.0.0
+        version: 2.0.33(zod@3.25.76)
+      '@ai-sdk/google':
+        specifier: ^2.0.0
+        version: 2.0.40(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^2.0.53
         version: 2.0.53(zod@3.25.76)


### PR DESCRIPTION
- Added `/connpass model` command group to manage AI model settings for channels.
- Implemented subcommands: `set`, `status`, `list`, and `reset` for model configuration.
- Introduced `IChannelModelStore` interface and `FileChannelModelStore` for persistent channel model settings.
- Enhanced progress embed to display model information.
- Updated summarizer to utilize channel-specific model configurations.
- Added autocomplete support for model names based on provider.
- Refactored AI model loading and validation logic into a dedicated module.
- Updated Docker configuration to support new AI provider environment variables.