### PR TITLE
Add admin and ban management features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ ANTHROPIC_API_KEY=
 GOOGLE_GENERATIVE_AI_API_KEY=
 
 # データ保存先 (オプション)
+# admins.json / bans.json もこのディレクトリに保存されます
 JOB_STORE_DIR=./data
 
 # AIエージェント有効化 (オプション、デフォルトtrue)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,17 @@ pnpm --filter @connpass-discord-bot/discord-bot start
 | `/connpass model set` | チャンネルのAIモデル設定 |
 | `/connpass model status` | モデル設定確認 |
 | `/connpass model reset` | モデル設定リセット |
+| `/connpass admin add` | 管理者追加 |
+| `/connpass admin remove` | 管理者削除 |
+| `/connpass admin ban` | ユーザーをBAN |
+| `/connpass admin unban` | BAN解除 |
+| `/connpass admin list` | 管理者/BAN一覧 |
 | `/connpass today` | 今日のイベント |
+
+**権限メモ**
+
+- 管理者未登録のときだけ `/connpass admin add` は誰でも実行可能
+- BANされたユーザーはAI機能、モデル変更、Feed変更ができません
 
 ### フィードの規模フィルタ
 

--- a/apps/discord-bot/src/commands/definitions.ts
+++ b/apps/discord-bot/src/commands/definitions.ts
@@ -160,6 +160,53 @@ export const connpassCommand = new SlashCommandBuilder()
       )
   )
 
+  // /connpass admin サブコマンドグループ
+  .addSubcommandGroup((group) =>
+    group
+      .setName('admin')
+      .setDescription('管理者とBANの管理')
+      .addSubcommand((sub) =>
+        sub
+          .setName('add')
+          .setDescription('管理者を追加')
+          .addUserOption((o) => o.setName('user').setDescription('追加するユーザー').setRequired(true))
+      )
+      .addSubcommand((sub) =>
+        sub
+          .setName('remove')
+          .setDescription('管理者を削除')
+          .addUserOption((o) => o.setName('user').setDescription('削除する管理者').setRequired(true))
+      )
+      .addSubcommand((sub) =>
+        sub
+          .setName('ban')
+          .setDescription('ユーザーをBAN')
+          .addUserOption((o) => o.setName('user').setDescription('BANするユーザー').setRequired(true))
+          .addStringOption((o) => o.setName('reason').setDescription('理由（任意）'))
+      )
+      .addSubcommand((sub) =>
+        sub
+          .setName('unban')
+          .setDescription('BANを解除')
+          .addUserOption((o) => o.setName('user').setDescription('解除するユーザー').setRequired(true))
+      )
+      .addSubcommand((sub) =>
+        sub
+          .setName('list')
+          .setDescription('管理者/バン一覧を表示')
+          .addStringOption((o) =>
+            o
+              .setName('type')
+              .setDescription('表示対象')
+              .addChoices(
+                { name: '管理者', value: 'admins' },
+                { name: 'バン', value: 'bans' },
+                { name: 'すべて', value: 'all' }
+              )
+          )
+      )
+  )
+
   // /connpass today
   .addSubcommand((sub) => sub.setName('today').setDescription('今日参加予定のイベントを表示'))
 

--- a/apps/discord-bot/src/commands/handlers/admin.ts
+++ b/apps/discord-bot/src/commands/handlers/admin.ts
@@ -1,0 +1,201 @@
+import type { ChatInputCommandInteraction } from 'discord.js';
+import type { IAdminStore, IBanStore, AdminUser, BannedUser } from '@connpass-discord-bot/core';
+import { hasAnyAdmin, isAdminUser, isBannedUser } from '../../security/permissions.js';
+
+const BAN_MESSAGE = '⛔ あなたはBANされているため、この操作は実行できません。';
+const ADMIN_ONLY_MESSAGE = '⛔ この操作は管理者のみ実行できます。';
+
+/**
+ * /connpass admin ハンドラー
+ */
+export async function handleAdminCommand(
+  interaction: ChatInputCommandInteraction,
+  adminStore: IAdminStore,
+  banStore: IBanStore
+): Promise<void> {
+  const subcommand = interaction.options.getSubcommand();
+  const requesterId = interaction.user.id;
+
+  if (await isBannedUser(banStore, requesterId)) {
+    await interaction.reply({ content: BAN_MESSAGE, ephemeral: true });
+    return;
+  }
+
+  const hasAdmins = await hasAnyAdmin(adminStore);
+  const isAdmin = await isAdminUser(adminStore, requesterId);
+
+  if (subcommand !== 'add' && !isAdmin) {
+    await interaction.reply({ content: ADMIN_ONLY_MESSAGE, ephemeral: true });
+    return;
+  }
+
+  if (subcommand === 'add' && hasAdmins && !isAdmin) {
+    await interaction.reply({ content: ADMIN_ONLY_MESSAGE, ephemeral: true });
+    return;
+  }
+
+  switch (subcommand) {
+    case 'add':
+      await handleAdminAdd(interaction, adminStore, requesterId, hasAdmins);
+      break;
+    case 'remove':
+      await handleAdminRemove(interaction, adminStore);
+      break;
+    case 'ban':
+      await handleAdminBan(interaction, banStore, requesterId);
+      break;
+    case 'unban':
+      await handleAdminUnban(interaction, banStore);
+      break;
+    case 'list':
+      await handleAdminList(interaction, adminStore, banStore);
+      break;
+    default:
+      await interaction.reply({ content: '未知のサブコマンドです', ephemeral: true });
+  }
+}
+
+async function handleAdminAdd(
+  interaction: ChatInputCommandInteraction,
+  adminStore: IAdminStore,
+  requesterId: string,
+  hasAdmins: boolean
+): Promise<void> {
+  const target = interaction.options.getUser('user', true);
+  const existing = await adminStore.find(target.id);
+  if (existing) {
+    await interaction.reply({
+      content: `⚠️ <@${target.id}> はすでに管理者です。`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const admin: AdminUser = {
+    discordUserId: target.id,
+    addedAt: new Date().toISOString(),
+    addedBy: hasAdmins ? requesterId : undefined,
+  };
+
+  await adminStore.save(admin);
+
+  const note = hasAdmins ? '' : '（管理者未登録のため、初回登録として受理しました）';
+  await interaction.reply({
+    content: `✅ <@${target.id}> を管理者に追加しました。${note}`,
+    ephemeral: true,
+  });
+}
+
+async function handleAdminRemove(
+  interaction: ChatInputCommandInteraction,
+  adminStore: IAdminStore
+): Promise<void> {
+  const target = interaction.options.getUser('user', true);
+  const existing = await adminStore.find(target.id);
+  if (!existing) {
+    await interaction.reply({
+      content: `⚠️ <@${target.id}> は管理者ではありません。`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await adminStore.delete(target.id);
+  await interaction.reply({
+    content: `✅ <@${target.id}> を管理者から削除しました。`,
+    ephemeral: true,
+  });
+}
+
+async function handleAdminBan(
+  interaction: ChatInputCommandInteraction,
+  banStore: IBanStore,
+  requesterId: string
+): Promise<void> {
+  const target = interaction.options.getUser('user', true);
+  const reason = interaction.options.getString('reason') ?? undefined;
+
+  const existing = await banStore.find(target.id);
+  if (existing) {
+    await interaction.reply({
+      content: `⚠️ <@${target.id}> はすでにBANされています。`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const ban: BannedUser = {
+    discordUserId: target.id,
+    bannedAt: new Date().toISOString(),
+    bannedBy: requesterId,
+    reason,
+  };
+
+  await banStore.save(ban);
+
+  await interaction.reply({
+    content: `✅ <@${target.id}> をBANしました。${reason ? `\n理由: ${reason}` : ''}`,
+    ephemeral: true,
+  });
+}
+
+async function handleAdminUnban(
+  interaction: ChatInputCommandInteraction,
+  banStore: IBanStore
+): Promise<void> {
+  const target = interaction.options.getUser('user', true);
+  const existing = await banStore.find(target.id);
+  if (!existing) {
+    await interaction.reply({
+      content: `⚠️ <@${target.id}> はBANされていません。`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await banStore.delete(target.id);
+  await interaction.reply({
+    content: `✅ <@${target.id}> のBANを解除しました。`,
+    ephemeral: true,
+  });
+}
+
+async function handleAdminList(
+  interaction: ChatInputCommandInteraction,
+  adminStore: IAdminStore,
+  banStore: IBanStore
+): Promise<void> {
+  const type = (interaction.options.getString('type') ?? 'all') as 'admins' | 'bans' | 'all';
+  const admins: AdminUser[] = type === 'bans' ? [] : await adminStore.list();
+  const bans: BannedUser[] = type === 'admins' ? [] : await banStore.list();
+
+  let message = '📋 **管理者/BAN一覧**\n\n';
+
+  if (type === 'admins' || type === 'all') {
+    message += `**管理者 (${admins.length})**\n`;
+    if (admins.length === 0) {
+      message += '（なし）\n\n';
+    } else {
+      message += admins
+        .map((admin) => `- <@${admin.discordUserId}> ${admin.addedAt ? `(${admin.addedAt})` : ''}`)
+        .join('\n');
+      message += '\n\n';
+    }
+  }
+
+  if (type === 'bans' || type === 'all') {
+    message += `**BAN (${bans.length})**\n`;
+    if (bans.length === 0) {
+      message += '（なし）';
+    } else {
+      message += bans
+        .map((ban) => {
+          const reason = ban.reason ? ` - ${ban.reason}` : '';
+          return `- <@${ban.discordUserId}> ${ban.bannedAt ? `(${ban.bannedAt})` : ''}${reason}`;
+        })
+        .join('\n');
+    }
+  }
+
+  await interaction.reply({ content: message.trimEnd(), ephemeral: true });
+}

--- a/apps/discord-bot/src/commands/handlers/feed.ts
+++ b/apps/discord-bot/src/commands/handlers/feed.ts
@@ -1,9 +1,10 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import type { Feed, FeedConfig, IFeedStore } from '@connpass-discord-bot/core';
+import type { Feed, FeedConfig, IFeedStore, IBanStore } from '@connpass-discord-bot/core';
 import { DEFAULTS } from '@connpass-discord-bot/core';
 import type { Scheduler, FeedExecutor } from '@connpass-discord-bot/feed-worker';
 import { CronExpressionParser } from 'cron-parser';
 import { getPrefectureName } from '../../data/prefectures.js';
+import { isBannedUser } from '../../security/permissions.js';
 
 /**
  * キーワード文字列をパース（カンマ/スペース区切り）
@@ -76,8 +77,16 @@ function validateCron(schedule: string): { valid: boolean; error?: string } {
 export async function handleFeedSet(
   interaction: ChatInputCommandInteraction,
   store: IFeedStore,
-  scheduler: Scheduler
+  scheduler: Scheduler,
+  banStore: IBanStore
 ): Promise<void> {
+  if (await isBannedUser(banStore, interaction.user.id)) {
+    await interaction.reply({
+      content: '⛔ あなたはBANされているため、Feedの変更はできません。',
+      ephemeral: true,
+    });
+    return;
+  }
   const channelId = interaction.channelId;
 
   // オプション取得
@@ -222,8 +231,16 @@ export async function handleFeedStatus(
 export async function handleFeedRemove(
   interaction: ChatInputCommandInteraction,
   store: IFeedStore,
-  scheduler: Scheduler
+  scheduler: Scheduler,
+  banStore: IBanStore
 ): Promise<void> {
+  if (await isBannedUser(banStore, interaction.user.id)) {
+    await interaction.reply({
+      content: '⛔ あなたはBANされているため、Feedの変更はできません。',
+      ephemeral: true,
+    });
+    return;
+  }
   const channelId = interaction.channelId;
   const feed = await store.get(channelId);
 
@@ -250,8 +267,16 @@ export async function handleFeedRemove(
 export async function handleFeedRun(
   interaction: ChatInputCommandInteraction,
   store: IFeedStore,
-  executor: FeedExecutor
+  executor: FeedExecutor,
+  banStore: IBanStore
 ): Promise<void> {
+  if (await isBannedUser(banStore, interaction.user.id)) {
+    await interaction.reply({
+      content: '⛔ あなたはBANされているため、Feedの変更はできません。',
+      ephemeral: true,
+    });
+    return;
+  }
   const channelId = interaction.channelId;
   const feed = await store.get(channelId);
 

--- a/apps/discord-bot/src/commands/handlers/help.ts
+++ b/apps/discord-bot/src/commands/handlers/help.ts
@@ -56,6 +56,17 @@ export async function handleHelp(interaction: ChatInputCommandInteraction): Prom
         value: 'ニックネームの登録を解除',
       },
       {
+        name: '/connpass admin add',
+        value: [
+          '**管理者/BAN管理**',
+          '`add` - 管理者追加（管理者未登録時は誰でも実行可）',
+          '`remove` - 管理者削除',
+          '`ban` - ユーザーをBAN',
+          '`unban` - BAN解除',
+          '`list` - 管理者/BAN一覧',
+        ].join('\n'),
+      },
+      {
         name: '/connpass today',
         value: '登録したニックネームで今日参加予定のイベントを表示',
       },

--- a/apps/discord-bot/src/security/permissions.ts
+++ b/apps/discord-bot/src/security/permissions.ts
@@ -1,0 +1,16 @@
+import type { IAdminStore, IBanStore } from '@connpass-discord-bot/core';
+
+export async function isAdminUser(adminStore: IAdminStore, discordUserId: string): Promise<boolean> {
+  const admin = await adminStore.find(discordUserId);
+  return Boolean(admin);
+}
+
+export async function hasAnyAdmin(adminStore: IAdminStore): Promise<boolean> {
+  const admins = await adminStore.list();
+  return admins.length > 0;
+}
+
+export async function isBannedUser(banStore: IBanStore, discordUserId: string): Promise<boolean> {
+  const banned = await banStore.find(discordUserId);
+  return Boolean(banned);
+}

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -69,6 +69,32 @@ export interface User {
 }
 
 /**
+ * 管理者ユーザー
+ */
+export interface AdminUser {
+  /** Discord ユーザーID */
+  discordUserId: string;
+  /** 追加日時（ISO string） */
+  addedAt: string;
+  /** 追加者（Discord ユーザーID） */
+  addedBy?: string;
+}
+
+/**
+ * バンされたユーザー
+ */
+export interface BannedUser {
+  /** Discord ユーザーID */
+  discordUserId: string;
+  /** バン日時（ISO string） */
+  bannedAt: string;
+  /** バン実行者（Discord ユーザーID） */
+  bannedBy?: string;
+  /** 理由 */
+  reason?: string;
+}
+
+/**
  * 新着イベント通知ペイロード
  */
 export interface NewEventsPayload {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,8 @@ export type {
   FeedState,
   Feed,
   User,
+  AdminUser,
+  BannedUser,
   NewEventsPayload,
   ConnpassEvent,
   // AI Agent 関連
@@ -18,6 +20,8 @@ export { ORDER_MAP, DEFAULTS } from './domain/types.js';
 // Repository interfaces
 export type { IFeedStore } from './repositories/IFeedStore.js';
 export type { IUserStore } from './repositories/IUserStore.js';
+export type { IAdminStore } from './repositories/IAdminStore.js';
+export type { IBanStore } from './repositories/IBanStore.js';
 export type { ISummaryCacheStore } from './repositories/ISummaryCacheStore.js';
 export type { IChannelModelStore } from './repositories/IChannelModelStore.js';
 

--- a/packages/core/src/repositories/IAdminStore.ts
+++ b/packages/core/src/repositories/IAdminStore.ts
@@ -1,0 +1,26 @@
+import type { AdminUser } from '../domain/types.js';
+
+/**
+ * 管理者保存インターフェース
+ */
+export interface IAdminStore {
+  /**
+   * 管理者を保存（作成または更新）
+   */
+  save(admin: AdminUser): Promise<void>;
+
+  /**
+   * 管理者を削除
+   */
+  delete(discordUserId: string): Promise<void>;
+
+  /**
+   * 管理者を取得
+   */
+  find(discordUserId: string): Promise<AdminUser | undefined>;
+
+  /**
+   * 管理者一覧を取得
+   */
+  list(): Promise<AdminUser[]>;
+}

--- a/packages/core/src/repositories/IBanStore.ts
+++ b/packages/core/src/repositories/IBanStore.ts
@@ -1,0 +1,26 @@
+import type { BannedUser } from '../domain/types.js';
+
+/**
+ * バン保存インターフェース
+ */
+export interface IBanStore {
+  /**
+   * バンを保存（作成または更新）
+   */
+  save(ban: BannedUser): Promise<void>;
+
+  /**
+   * バンを削除
+   */
+  delete(discordUserId: string): Promise<void>;
+
+  /**
+   * バンを取得
+   */
+  find(discordUserId: string): Promise<BannedUser | undefined>;
+
+  /**
+   * バン一覧を取得
+   */
+  list(): Promise<BannedUser[]>;
+}

--- a/packages/feed-worker/src/index.ts
+++ b/packages/feed-worker/src/index.ts
@@ -3,6 +3,10 @@ export { InMemoryFeedStore } from './storage/InMemoryFeedStore.js';
 export { FileFeedStore } from './storage/FileFeedStore.js';
 export { InMemoryUserStore } from './storage/InMemoryUserStore.js';
 export { FileUserStore } from './storage/FileUserStore.js';
+export { InMemoryAdminStore } from './storage/InMemoryAdminStore.js';
+export { FileAdminStore } from './storage/FileAdminStore.js';
+export { InMemoryBanStore } from './storage/InMemoryBanStore.js';
+export { FileBanStore } from './storage/FileBanStore.js';
 export { FileSummaryCacheStore } from './storage/FileSummaryCacheStore.js';
 export { FileChannelModelStore } from './storage/FileChannelModelStore.js';
 

--- a/packages/feed-worker/src/storage/FileAdminStore.ts
+++ b/packages/feed-worker/src/storage/FileAdminStore.ts
@@ -1,0 +1,72 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { AdminUser, IAdminStore } from '@connpass-discord-bot/core';
+
+interface StoredData {
+  admins: Record<string, AdminUser>;
+}
+
+/**
+ * ファイルベース管理者ストア
+ */
+export class FileAdminStore implements IAdminStore {
+  private filePath: string;
+  private data: StoredData | null = null;
+
+  constructor(storeDir: string) {
+    this.filePath = join(storeDir, 'admins.json');
+  }
+
+  private async load(): Promise<StoredData> {
+    if (this.data) return this.data;
+
+    if (!existsSync(this.filePath)) {
+      this.data = { admins: {} };
+      return this.data;
+    }
+
+    try {
+      const content = await readFile(this.filePath, 'utf-8');
+      this.data = JSON.parse(content) as StoredData;
+    } catch {
+      this.data = { admins: {} };
+    }
+
+    return this.data;
+  }
+
+  private async persist(): Promise<void> {
+    if (!this.data) return;
+
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true });
+    }
+
+    await writeFile(this.filePath, JSON.stringify(this.data, null, 2), 'utf-8');
+  }
+
+  async save(admin: AdminUser): Promise<void> {
+    const data = await this.load();
+    data.admins[admin.discordUserId] = structuredClone(admin);
+    await this.persist();
+  }
+
+  async delete(discordUserId: string): Promise<void> {
+    const data = await this.load();
+    delete data.admins[discordUserId];
+    await this.persist();
+  }
+
+  async find(discordUserId: string): Promise<AdminUser | undefined> {
+    const data = await this.load();
+    const admin = data.admins[discordUserId];
+    return admin ? structuredClone(admin) : undefined;
+  }
+
+  async list(): Promise<AdminUser[]> {
+    const data = await this.load();
+    return Object.values(data.admins).map((admin) => structuredClone(admin));
+  }
+}

--- a/packages/feed-worker/src/storage/FileBanStore.ts
+++ b/packages/feed-worker/src/storage/FileBanStore.ts
@@ -1,0 +1,72 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { BannedUser, IBanStore } from '@connpass-discord-bot/core';
+
+interface StoredData {
+  bans: Record<string, BannedUser>;
+}
+
+/**
+ * ファイルベースバンストア
+ */
+export class FileBanStore implements IBanStore {
+  private filePath: string;
+  private data: StoredData | null = null;
+
+  constructor(storeDir: string) {
+    this.filePath = join(storeDir, 'bans.json');
+  }
+
+  private async load(): Promise<StoredData> {
+    if (this.data) return this.data;
+
+    if (!existsSync(this.filePath)) {
+      this.data = { bans: {} };
+      return this.data;
+    }
+
+    try {
+      const content = await readFile(this.filePath, 'utf-8');
+      this.data = JSON.parse(content) as StoredData;
+    } catch {
+      this.data = { bans: {} };
+    }
+
+    return this.data;
+  }
+
+  private async persist(): Promise<void> {
+    if (!this.data) return;
+
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true });
+    }
+
+    await writeFile(this.filePath, JSON.stringify(this.data, null, 2), 'utf-8');
+  }
+
+  async save(ban: BannedUser): Promise<void> {
+    const data = await this.load();
+    data.bans[ban.discordUserId] = structuredClone(ban);
+    await this.persist();
+  }
+
+  async delete(discordUserId: string): Promise<void> {
+    const data = await this.load();
+    delete data.bans[discordUserId];
+    await this.persist();
+  }
+
+  async find(discordUserId: string): Promise<BannedUser | undefined> {
+    const data = await this.load();
+    const ban = data.bans[discordUserId];
+    return ban ? structuredClone(ban) : undefined;
+  }
+
+  async list(): Promise<BannedUser[]> {
+    const data = await this.load();
+    return Object.values(data.bans).map((ban) => structuredClone(ban));
+  }
+}

--- a/packages/feed-worker/src/storage/InMemoryAdminStore.ts
+++ b/packages/feed-worker/src/storage/InMemoryAdminStore.ts
@@ -1,0 +1,25 @@
+import type { AdminUser, IAdminStore } from '@connpass-discord-bot/core';
+
+/**
+ * インメモリ管理者ストア（テスト・開発用）
+ */
+export class InMemoryAdminStore implements IAdminStore {
+  private admins = new Map<string, AdminUser>();
+
+  async save(admin: AdminUser): Promise<void> {
+    this.admins.set(admin.discordUserId, structuredClone(admin));
+  }
+
+  async delete(discordUserId: string): Promise<void> {
+    this.admins.delete(discordUserId);
+  }
+
+  async find(discordUserId: string): Promise<AdminUser | undefined> {
+    const admin = this.admins.get(discordUserId);
+    return admin ? structuredClone(admin) : undefined;
+  }
+
+  async list(): Promise<AdminUser[]> {
+    return Array.from(this.admins.values()).map((admin) => structuredClone(admin));
+  }
+}

--- a/packages/feed-worker/src/storage/InMemoryBanStore.ts
+++ b/packages/feed-worker/src/storage/InMemoryBanStore.ts
@@ -1,0 +1,25 @@
+import type { BannedUser, IBanStore } from '@connpass-discord-bot/core';
+
+/**
+ * インメモリバンストア（テスト・開発用）
+ */
+export class InMemoryBanStore implements IBanStore {
+  private bans = new Map<string, BannedUser>();
+
+  async save(ban: BannedUser): Promise<void> {
+    this.bans.set(ban.discordUserId, structuredClone(ban));
+  }
+
+  async delete(discordUserId: string): Promise<void> {
+    this.bans.delete(discordUserId);
+  }
+
+  async find(discordUserId: string): Promise<BannedUser | undefined> {
+    const ban = this.bans.get(discordUserId);
+    return ban ? structuredClone(ban) : undefined;
+  }
+
+  async list(): Promise<BannedUser[]> {
+    return Array.from(this.bans.values()).map((ban) => structuredClone(ban));
+  }
+}


### PR DESCRIPTION
Introduce functionality for managing administrators and banning users, including interfaces for storage and commands for adding, removing, and listing admins and banned users. Additionally, implement file-based and in-memory storage solutions for both admins and bans.