### PR TITLE
feat: Add DB cleanup scheduler to prevent database bloat

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,15 @@ OPENAI_API_KEY=sk-...
 ANTHROPIC_API_KEY=sk-ant-...
 GOOGLE_GENERATIVE_AI_API_KEY=...
 
+# ストレージ設定
+STORAGE_TYPE=sqlite          # sqlite（推奨）または file
+DATABASE_URL=./data/app.db   # SQLite DBファイルパス
+JOB_STORE_DIR=./data         # Fileストレージ使用時のディレクトリ
+
 # オプション
-JOB_STORE_DIR=./data
 ENABLE_AI_AGENT=true
+LOG_LEVEL=info               # debug, info, warn, error
+LOG_DESTINATION=both         # console, database, both
 ```
 
 ### 3. コマンド登録
@@ -160,6 +166,22 @@ AIモデルはチャンネルごとに設定可能です。OpenAI、Claude、Gem
 | OpenAI | `OPENAI_API_KEY` | gpt-4o-mini |
 | Anthropic (Claude) | `ANTHROPIC_API_KEY` | claude-3-5-haiku-20241022 |
 | Google (Gemini) | `GOOGLE_GENERATIVE_AI_API_KEY` | gemini-1.5-flash |
+
+## データベースクリーンアップ
+
+SQLiteストレージ使用時、古いデータは自動的にクリーンアップされます。
+
+### デフォルト保持期間
+
+| データ | 保持期間 | 説明 |
+|-------|---------|------|
+| アプリログ (`app_logs`) | 7日 | デバッグ・トラブルシューティング用 |
+| アクションログ (`action_logs`) | 30日 | ユーザー操作の監査ログ |
+| 送信済みイベント (`feed_sent_events`) | 90日 | 重複送信防止用 |
+| イベント要約キャッシュ (`event_summary_cache`) | 30日 | AI要約のキャッシュ |
+| 通知送信済み (`user_notify_sent_events`) | 30日 | DM通知の重複防止用 |
+
+クリーンアップは起動時と24時間ごとに自動実行されます。
 
 ## 構成
 

--- a/packages/feed-worker/src/db/schema/feeds.ts
+++ b/packages/feed-worker/src/db/schema/feeds.ts
@@ -26,6 +26,7 @@ export const feedSentEvents = sqliteTable(
       .references(() => feeds.id, { onDelete: 'cascade' }),
     eventId: integer('event_id').notNull(),
     updatedAt: text('updated_at').notNull(),
+    sentAt: text('sent_at').notNull(),
   },
   (table) => [primaryKey({ columns: [table.feedId, table.eventId] })]
 );

--- a/packages/feed-worker/src/index.ts
+++ b/packages/feed-worker/src/index.ts
@@ -43,3 +43,12 @@ export type {
   NotifySchedulerOptions,
   INotifySink,
 } from './scheduler/NotifyScheduler.js';
+
+// Cleanup Scheduler
+export { CleanupScheduler } from './scheduler/CleanupScheduler.js';
+export type {
+  CleanupSchedulerOptions,
+  CleanupConfig,
+  CleanupStores,
+  CleanupResult,
+} from './scheduler/CleanupScheduler.js';

--- a/packages/feed-worker/src/scheduler/CleanupScheduler.ts
+++ b/packages/feed-worker/src/scheduler/CleanupScheduler.ts
@@ -1,0 +1,214 @@
+import { Logger, LogLevel, ActionType } from '@connpass-discord-bot/core';
+import type { DrizzleLogWriter } from '../storage/drizzle/DrizzleLogWriter.js';
+import type { DrizzleFeedStore } from '../storage/drizzle/DrizzleFeedStore.js';
+import type { DrizzleSummaryCacheStore } from '../storage/drizzle/DrizzleSummaryCacheStore.js';
+import type { DrizzleUserNotifySentStore } from '../storage/drizzle/DrizzleUserNotifySentStore.js';
+
+const logger = Logger.getInstance();
+
+/**
+ * クリーンアップ対象と保持日数の設定
+ */
+export interface CleanupConfig {
+  /** アプリログの保持日数（デフォルト: 7日） */
+  appLogRetentionDays?: number;
+  /** アクションログの保持日数（デフォルト: 30日） */
+  actionLogRetentionDays?: number;
+  /** 送信済みイベントの保持日数（デフォルト: 90日） */
+  feedSentEventsRetentionDays?: number;
+  /** イベント要約キャッシュの保持日数（デフォルト: 30日） */
+  summaryCacheRetentionDays?: number;
+  /** 通知送信済みの保持日数（デフォルト: 30日） */
+  notifySentRetentionDays?: number;
+}
+
+/**
+ * クリーンアップ対象のストア群
+ */
+export interface CleanupStores {
+  logWriter?: DrizzleLogWriter;
+  feedStore?: DrizzleFeedStore;
+  summaryCacheStore?: DrizzleSummaryCacheStore;
+  notifySentStore?: DrizzleUserNotifySentStore;
+}
+
+export interface CleanupSchedulerOptions {
+  /** チェック間隔（ミリ秒）。デフォルト: 86400000 (24時間) */
+  checkIntervalMs?: number;
+  /** 保持期間設定 */
+  config?: CleanupConfig;
+}
+
+/**
+ * クリーンアップ結果
+ */
+export interface CleanupResult {
+  appLogs: number;
+  actionLogs: number;
+  feedSentEvents: number;
+  summaryCache: number;
+  notifySent: number;
+  totalDeleted: number;
+}
+
+/**
+ * DBクリーンアップスケジューラー
+ * 古いレコードを定期的に削除してDBサイズの肥大化を防ぐ
+ */
+export class CleanupScheduler {
+  private checkInterval?: ReturnType<typeof setInterval>;
+  private readonly checkIntervalMs: number;
+  private readonly config: Required<CleanupConfig>;
+  private isRunning = false;
+
+  constructor(
+    private readonly stores: CleanupStores,
+    options: CleanupSchedulerOptions = {}
+  ) {
+    this.checkIntervalMs = options.checkIntervalMs ?? 24 * 60 * 60 * 1000; // 24時間
+    this.config = {
+      appLogRetentionDays: options.config?.appLogRetentionDays ?? 7,
+      actionLogRetentionDays: options.config?.actionLogRetentionDays ?? 30,
+      feedSentEventsRetentionDays: options.config?.feedSentEventsRetentionDays ?? 90,
+      summaryCacheRetentionDays: options.config?.summaryCacheRetentionDays ?? 30,
+      notifySentRetentionDays: options.config?.notifySentRetentionDays ?? 30,
+    };
+  }
+
+  /**
+   * スケジューラーを開始
+   */
+  async start(): Promise<void> {
+    if (this.isRunning) return;
+    this.isRunning = true;
+
+    // 起動時に即座にクリーンアップ実行
+    await this.runCleanup();
+
+    // 定期クリーンアップループ開始
+    this.checkInterval = setInterval(() => {
+      this.runCleanup().catch((error) => {
+        logger.error('CleanupScheduler', 'Cleanup cycle failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }, this.checkIntervalMs);
+
+    logger.logAction({
+      level: LogLevel.INFO,
+      actionType: ActionType.SCHEDULER_START,
+      component: 'CleanupScheduler',
+      message: `CleanupScheduler started with ${this.checkIntervalMs}ms interval`,
+      metadata: {
+        checkIntervalMs: this.checkIntervalMs,
+        config: this.config,
+      },
+    });
+  }
+
+  /**
+   * スケジューラーを停止
+   */
+  async stop(): Promise<void> {
+    if (this.checkInterval) {
+      clearInterval(this.checkInterval);
+      this.checkInterval = undefined;
+    }
+    this.isRunning = false;
+    logger.logAction({
+      level: LogLevel.INFO,
+      actionType: ActionType.SCHEDULER_STOP,
+      component: 'CleanupScheduler',
+      message: 'CleanupScheduler stopped',
+    });
+  }
+
+  /**
+   * クリーンアップを即座に実行
+   */
+  async runCleanup(): Promise<CleanupResult> {
+    const result: CleanupResult = {
+      appLogs: 0,
+      actionLogs: 0,
+      feedSentEvents: 0,
+      summaryCache: 0,
+      notifySent: 0,
+      totalDeleted: 0,
+    };
+
+    const startTime = Date.now();
+
+    try {
+      // アプリログのクリーンアップ
+      if (this.stores.logWriter) {
+        result.appLogs = await this.stores.logWriter.cleanupAppLogs(
+          this.config.appLogRetentionDays
+        );
+        result.actionLogs = await this.stores.logWriter.cleanupActionLogs(
+          this.config.actionLogRetentionDays
+        );
+      }
+
+      // 送信済みイベントのクリーンアップ
+      if (this.stores.feedStore) {
+        result.feedSentEvents = await this.stores.feedStore.cleanupSentEvents(
+          this.config.feedSentEventsRetentionDays
+        );
+      }
+
+      // 要約キャッシュのクリーンアップ
+      if (this.stores.summaryCacheStore) {
+        result.summaryCache = await this.stores.summaryCacheStore.cleanup(
+          this.config.summaryCacheRetentionDays
+        );
+      }
+
+      // 通知送信済みのクリーンアップ
+      if (this.stores.notifySentStore) {
+        result.notifySent = await this.stores.notifySentStore.cleanupOlderThan(
+          this.config.notifySentRetentionDays
+        );
+      }
+
+      result.totalDeleted =
+        result.appLogs +
+        result.actionLogs +
+        result.feedSentEvents +
+        result.summaryCache +
+        result.notifySent;
+
+      const duration = Date.now() - startTime;
+
+      if (result.totalDeleted > 0) {
+        logger.logAction({
+          level: LogLevel.INFO,
+          actionType: ActionType.GENERAL,
+          component: 'CleanupScheduler',
+          message: `Cleanup completed: ${result.totalDeleted} records deleted`,
+          metadata: {
+            ...result,
+            durationMs: duration,
+          },
+        });
+      } else {
+        logger.debug('CleanupScheduler', 'Cleanup completed: no records to delete', {
+          durationMs: duration,
+        });
+      }
+
+      return result;
+    } catch (error) {
+      logger.error('CleanupScheduler', 'Cleanup failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * 現在の設定を取得
+   */
+  getConfig(): Readonly<Required<CleanupConfig>> {
+    return { ...this.config };
+  }
+}

--- a/packages/feed-worker/src/storage/drizzle/DrizzleLogWriter.ts
+++ b/packages/feed-worker/src/storage/drizzle/DrizzleLogWriter.ts
@@ -1,3 +1,4 @@
+import { lt } from 'drizzle-orm';
 import type { ILogWriter, LogEntry, ActionLogEntry } from '@connpass-discord-bot/core';
 import type { DrizzleDB } from '../../db/index.js';
 import { appLogs, actionLogs } from '../../db/schema/index.js';
@@ -7,6 +8,32 @@ import { appLogs, actionLogs } from '../../db/schema/index.js';
  */
 export class DrizzleLogWriter implements ILogWriter {
   constructor(private db: DrizzleDB) {}
+
+  /**
+   * 指定日数より古いアプリログを削除
+   * @param olderThanDays 削除対象の日数
+   * @returns 削除された行数
+   */
+  async cleanupAppLogs(olderThanDays: number): Promise<number> {
+    const cutoffMs = Date.now() - olderThanDays * 24 * 60 * 60 * 1000;
+    const result = await this.db
+      .delete(appLogs)
+      .where(lt(appLogs.timestamp, cutoffMs));
+    return result.changes ?? 0;
+  }
+
+  /**
+   * 指定日数より古いアクションログを削除
+   * @param olderThanDays 削除対象の日数
+   * @returns 削除された行数
+   */
+  async cleanupActionLogs(olderThanDays: number): Promise<number> {
+    const cutoffMs = Date.now() - olderThanDays * 24 * 60 * 60 * 1000;
+    const result = await this.db
+      .delete(actionLogs)
+      .where(lt(actionLogs.timestamp, cutoffMs));
+    return result.changes ?? 0;
+  }
 
   write(entry: LogEntry): void {
     // 非同期で書き込み（エラーは無視）


### PR DESCRIPTION
- Add CleanupScheduler with configurable retention periods:
  - app_logs: 7 days (default)
  - action_logs: 30 days (default)
  - feed_sent_events: 90 days (default)
  - summary_cache: 30 days (default)
  - notify_sent: 30 days (default)

- Add cleanup methods to DrizzleLogWriter (cleanupAppLogs, cleanupActionLogs)
- Add cleanupSentEvents method to DrizzleFeedStore
- Integrate CleanupScheduler into discord-bot startup
- Run cleanup on startup and daily thereafter