### PR TITLE
fix: エージェントのシステムプロンプトにchannelIdを含める

### DIFF
--- a/apps/discord-bot/src/agent/connpass-agent.ts
+++ b/apps/discord-bot/src/agent/connpass-agent.ts
@@ -682,11 +682,13 @@ export function createConnpassAgent(channelModelConfig?: ChannelModelConfig | nu
       });
       const currentDate = jstFormatter.format(now);
       
+      const currentChannelId = runtimeContext?.get('channelId') as string | undefined;
       const dynamicContext = `
 
 ## Current Context
 **Today's date: ${currentDate} (JST/Asia/Tokyo)**
-Use this as the reference for "today", "tomorrow", "this week", etc.`;
+Use this as the reference for "today", "tomorrow", "this week", etc.
+${currentChannelId ? `**Current channel ID: ${currentChannelId}**\nUse this channel ID for feed management and other channel-specific operations. Do NOT ask the user for the channel ID.` : ''}`;
 
       const eventContext = runtimeContext?.get('eventContext') as string | undefined;
       


### PR DESCRIPTION
channelIdはruntimeContextにセットされていたが、エージェントの
instructionsには含まれていなかった。そのためLLMは現在のチャンネルIDを
認識できず、フィード操作時にユーザーに毎回channelIdを尋ねていた。

dynamicContextにcurrentChannelIdを追加し、LLMがチャンネルIDを
把握した上でツールを呼び出せるようにした。

https://claude.ai/code/session_0164Ek3arSS7b2VYTXuZ1N17